### PR TITLE
Run tests when verifying examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "elm-verify-examples"
+    "test": "elm-verify-examples --run-tests"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I noticed that locally and in CI just `elm-verify-examples` runs but it doesn't run the Elm tests. Maybe this was intentional? I'm not familiar with `elm-verify-examples` and why would you want to run it without also running the tests.